### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,14 +9,14 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "next": "13.4.12",
+    "next": "14.0.4",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },
   "devDependencies": {
-    "typescript": "5.2.2",
-    "@types/react": "18.2.14",
-    "@types/node": "20.6.1",
-    "eslint": "8.50.0"
+    "typescript": "5.3.3",
+    "@types/react": "18.2.21",
+    "@types/node": "20.10.5",
+    "eslint": "8.56.0"
   }
 }


### PR DESCRIPTION
## Summary
- bump Next.js to v14.0.4
- bump TypeScript and lint/type packages

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68468f7365948331ae1b40019d603f89