### PR TITLE
Add portfolio pages and contact API

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "next": "14.0.4",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "nodemailer": "^6.9.11"
   },
   "devDependencies": {
     "typescript": "5.3.3",

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -1,0 +1,16 @@
+import Head from 'next/head'
+
+export default function About() {
+  return (
+    <div className="px-8">
+      <Head>
+        <title>About - Portfolio</title>
+        <meta name="description" content="Learn more about the person behind this portfolio." />
+      </Head>
+      <main className="min-h-screen py-16">
+        <h1 className="text-4xl font-bold mb-4">About Me</h1>
+        <p>Write something about yourself here.</p>
+      </main>
+    </div>
+  )
+}

--- a/pages/achievements.tsx
+++ b/pages/achievements.tsx
@@ -1,0 +1,16 @@
+import Head from 'next/head'
+
+export default function Achievements() {
+  return (
+    <div className="px-8">
+      <Head>
+        <title>Achievements - Portfolio</title>
+        <meta name="description" content="Awards and notable achievements." />
+      </Head>
+      <main className="min-h-screen py-16">
+        <h1 className="text-4xl font-bold mb-4">Achievements</h1>
+        <p>Share your achievements here.</p>
+      </main>
+    </div>
+  )
+}

--- a/pages/api/contact.ts
+++ b/pages/api/contact.ts
@@ -1,0 +1,44 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import nodemailer from 'nodemailer'
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST'])
+    return res.status(405).end(`Method ${req.method} Not Allowed`)
+  }
+
+  const { name, email, message } = req.body
+  if (!name || !email || !message) {
+    return res.status(400).json({ error: 'Missing fields' })
+  }
+
+  const user = process.env.CONTACT_EMAIL_USER
+  const pass = process.env.CONTACT_EMAIL_PASS
+
+  if (!user || !pass) {
+    return res.status(500).json({ error: 'Email credentials not configured' })
+  }
+
+  try {
+    const transporter = nodemailer.createTransport({
+      service: 'gmail',
+      auth: { user, pass },
+    })
+
+    await transporter.sendMail({
+      from: user,
+      to: user,
+      replyTo: email,
+      subject: `Portfolio Contact Form: ${name}`,
+      text: message,
+    })
+
+    return res.status(200).json({ success: true })
+  } catch (err) {
+    console.error('Email error:', err)
+    return res.status(500).json({ error: 'Failed to send email' })
+  }
+}

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react'
+import Head from 'next/head'
+
+export default function Contact() {
+  const [status, setStatus] = useState<string | null>(null)
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    const form = e.currentTarget
+    const data = {
+      name: form.name.value,
+      email: form.email.value,
+      message: form.message.value,
+    }
+
+    try {
+      const res = await fetch('/api/contact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      })
+      if (res.ok) {
+        setStatus('Message sent!')
+        form.reset()
+      } else {
+        const body = await res.json()
+        setStatus(body.error || 'Something went wrong')
+      }
+    } catch (err) {
+      setStatus('Failed to submit form')
+    }
+  }
+
+  return (
+    <div className="px-8">
+      <Head>
+        <title>Contact - Portfolio</title>
+        <meta name="description" content="Get in touch using the contact form." />
+      </Head>
+      <main className="min-h-screen py-16">
+        <h1 className="text-4xl font-bold mb-4">Contact</h1>
+        <form onSubmit={handleSubmit} className="max-w-md space-y-4">
+          <input className="w-full p-2 border" name="name" placeholder="Name" required />
+          <input className="w-full p-2 border" name="email" type="email" placeholder="Email" required />
+          <textarea className="w-full p-2 border" name="message" placeholder="Message" required />
+          <button type="submit" className="px-4 py-2 bg-blue-500 text-white">Send</button>
+        </form>
+        {status && <p className="mt-4">{status}</p>}
+      </main>
+    </div>
+  )
+}

--- a/pages/experience.tsx
+++ b/pages/experience.tsx
@@ -1,0 +1,16 @@
+import Head from 'next/head'
+
+export default function Experience() {
+  return (
+    <div className="px-8">
+      <Head>
+        <title>Experience - Portfolio</title>
+        <meta name="description" content="Professional work and experiences." />
+      </Head>
+      <main className="min-h-screen py-16">
+        <h1 className="text-4xl font-bold mb-4">Experience</h1>
+        <p>Highlight your work history here.</p>
+      </main>
+    </div>
+  )
+}

--- a/pages/projects.tsx
+++ b/pages/projects.tsx
@@ -1,0 +1,16 @@
+import Head from 'next/head'
+
+export default function Projects() {
+  return (
+    <div className="px-8">
+      <Head>
+        <title>Projects - Portfolio</title>
+        <meta name="description" content="A showcase of my projects and work." />
+      </Head>
+      <main className="min-h-screen py-16">
+        <h1 className="text-4xl font-bold mb-4">Projects</h1>
+        <p>Describe your projects here.</p>
+      </main>
+    </div>
+  )
+}

--- a/pages/skills.tsx
+++ b/pages/skills.tsx
@@ -1,0 +1,16 @@
+import Head from 'next/head'
+
+export default function Skills() {
+  return (
+    <div className="px-8">
+      <Head>
+        <title>Skills - Portfolio</title>
+        <meta name="description" content="Technical skills and proficiencies." />
+      </Head>
+      <main className="min-h-screen py-16">
+        <h1 className="text-4xl font-bold mb-4">Skills</h1>
+        <p>List your skills here.</p>
+      </main>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add about, experience, projects, skills, achievements, and contact pages
- implement `/api/contact` endpoint using Nodemailer
- wire up a contact form on the new contact page
- add Nodemailer dependency

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684690d365848331ae12f3d79b35179e