### PR TITLE
Add placeholder images and use next/image

### DIFF
--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -1,12 +1,22 @@
+import Image from 'next/image'
+
 interface Props {
   title: string
   description: string
+  imageSrc: string
   link?: string
 }
 
-export default function ProjectCard({ title, description, link }: Props) {
+export default function ProjectCard({ title, description, imageSrc, link }: Props) {
   return (
     <article className="border rounded p-4" aria-labelledby={title.replace(/\s+/g, '-') + '-title'}>
+      <Image
+        src={imageSrc}
+        alt={title + ' screenshot'}
+        width={600}
+        height={400}
+        className="mb-2 rounded"
+      />
       <h3 id={title.replace(/\s+/g, '-') + '-title'} className="text-xl font-semibold mb-2">
         {title}
       </h3>

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -1,4 +1,5 @@
 import Head from 'next/head'
+import Image from 'next/image'
 
 export default function About() {
   return (
@@ -7,6 +8,13 @@ export default function About() {
         <title>About - Portfolio</title>
         <meta name="description" content="Learn more about the person behind this portfolio." />
       </Head>
+      <Image
+        src="/images/profile.svg"
+        alt="Profile photo"
+        width={200}
+        height={200}
+        className="mx-auto rounded-full mb-4"
+      />
       <h1 className="text-4xl font-bold mb-4">About Me</h1>
       <p>Write something about yourself here.</p>
     </>

--- a/pages/projects.tsx
+++ b/pages/projects.tsx
@@ -10,8 +10,18 @@ export default function Projects() {
       </Head>
       <h1 className="text-4xl font-bold mb-4">Projects</h1>
       <div className="grid gap-4 md:grid-cols-2">
-        <ProjectCard title="Project One" description="Description of project one." link="#" />
-        <ProjectCard title="Project Two" description="Description of project two." link="#" />
+        <ProjectCard
+          title="Project One"
+          description="Description of project one."
+          imageSrc="/images/project1.svg"
+          link="#"
+        />
+        <ProjectCard
+          title="Project Two"
+          description="Description of project two."
+          imageSrc="/images/project2.svg"
+          link="#"
+        />
       </div>
     </>
   )

--- a/public/images/profile.svg
+++ b/public/images/profile.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
+  <rect width="200" height="200" fill="#cccccc" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="24" fill="#555555">Profile</text>
+</svg>

--- a/public/images/project1.svg
+++ b/public/images/project1.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400" viewBox="0 0 600 400">
+  <rect width="600" height="400" fill="#e0e0e0" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="32" fill="#555555">Project 1</text>
+</svg>

--- a/public/images/project2.svg
+++ b/public/images/project2.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400" viewBox="0 0 600 400">
+  <rect width="600" height="400" fill="#d0d0d0" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="32" fill="#555555">Project 2</text>
+</svg>


### PR DESCRIPTION
## Summary
- add placeholder profile photo and project images
- implement `next/image` for optimized loading
- remove empty `public/README`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846929a042c8331b15c09831d7342c1