### PR TITLE
Update portfolio sections

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -2,7 +2,7 @@ export default function Footer() {
   return (
     <footer className="bg-gray-900 text-gray-300 mt-auto" role="contentinfo">
       <div className="container mx-auto px-4 py-6 text-center text-sm">
-        &copy; {new Date().getFullYear()} Your Name
+        &copy; {new Date().getFullYear()} Anant Kumar Srivastava
       </div>
     </footer>
   )

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -8,7 +8,7 @@ export default function Hero() {
       aria-label="Introduction"
     >
       <h1 className="text-6xl font-extrabold mb-6">Hi, I'm Anant Kumar Srivastava.</h1>
-      <p className="text-2xl mb-8">A passionate developer crafting beautiful web experiences.</p>
+      <p className="text-2xl mb-8">Software engineer building data-driven services and user-friendly tools.</p>
       <Link
         href="#projects"
         className="inline-block bg-white text-indigo-700 px-6 py-3 rounded shadow hover:bg-gray-100"

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -4,7 +4,7 @@ export default function Navbar() {
   return (
     <header className="bg-gradient-to-r from-indigo-600 via-purple-600 to-pink-600 text-white shadow-md sticky top-0 z-50">
       <nav className="container mx-auto flex items-center justify-between p-4" aria-label="Main navigation">
-        <Link href="/" className="text-xl font-semibold">Your Name</Link>
+        <Link href="/" className="text-xl font-semibold">Anant Kumar Srivastava</Link>
         <ul className="flex space-x-4">
           <li>
             <Link href="#about" className="hover:text-yellow-300">

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -16,7 +16,12 @@ export default function About() {
         className="mx-auto rounded-full mb-4"
       />
       <h1 className="text-4xl font-bold mb-4">About Me</h1>
-      <p>Write something about yourself here.</p>
+      <p>
+        I'm Anant Kumar Srivastava, a software engineer with a B.E. in Electronics
+        and Instrumentation and an M.Sc. in Mathematics from BITS Pilani
+        (2019–2024). I enjoy creating scalable data systems and simple user
+        experiences.
+      </p>
     </>
   )
 }

--- a/pages/achievements.tsx
+++ b/pages/achievements.tsx
@@ -8,7 +8,16 @@ export default function Achievements() {
         <meta name="description" content="Awards and notable achievements." />
       </Head>
       <h1 className="text-4xl font-bold mb-4">Achievements</h1>
-      <p>Share your achievements here.</p>
+      <ul className="list-disc list-inside text-left">
+        <li>
+          Global rank&nbsp;103 among 10k+ participants in a CodeChef Div&nbsp;2
+          contest.
+        </li>
+        <li>
+          Keyboard player certified by Trinity College London with one of its
+          highest rankings.
+        </li>
+      </ul>
     </>
   )
 }

--- a/pages/experience.tsx
+++ b/pages/experience.tsx
@@ -10,11 +10,28 @@ export default function Experience() {
       </Head>
       <h1 className="text-4xl font-bold mb-4">Experience</h1>
       <ul className="border-l-2 border-gray-300 ml-2">
-        <TimelineItem title="Company A" subtitle="Role" date="2020 - Present">
-          Brief description of your role at Company A.
+        <TimelineItem
+          title="Nielsen Media"
+          subtitle="Member of Technical Staff"
+          date="Jul 2024 - Present"
+        >
+          Developed event-driven microservices and automated data pipelines using
+          AWS, Redis, and Airflow.
         </TimelineItem>
-        <TimelineItem title="Company B" subtitle="Role" date="2018 - 2020">
-          Brief description of your role at Company B.
+        <TimelineItem
+          title="SAP Labs"
+          subtitle="Developer Intern"
+          date="Feb 2024 - Jul 2024"
+        >
+          Created an SAPUI5 logging plugin and internal DevOps tools with Jira
+          integrations.
+        </TimelineItem>
+        <TimelineItem
+          title="IIIT Delhi"
+          subtitle="R&amp;D Intern"
+          date="Jun 2023 - Dec 2023"
+        >
+          Built a mobile app for patented research using smartphone sensors.
         </TimelineItem>
       </ul>
     </>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -61,7 +61,12 @@ export default function Home() {
           className="mx-auto rounded-full mb-4"
         />
         <h1 className="text-4xl font-bold mb-4">About Me</h1>
-        <p>Write something about yourself here.</p>
+        <p>
+          I'm Anant Kumar Srivastava, a software engineer with a B.E. in
+          Electronics and Instrumentation and an M.Sc. in Mathematics from BITS
+          Pilani (2019–2024). I enjoy creating scalable data systems and simple
+          user experiences.
+        </p>
       </motion.section>
 
       <motion.section
@@ -75,14 +80,14 @@ export default function Home() {
         <h1 className="text-4xl font-bold mb-4">Projects</h1>
         <div className="grid gap-4 md:grid-cols-2">
           <ProjectCard
-            title="Project One"
-            description="Description of project one."
+            title="Codeforces POTD Extension"
+            description="Chrome extension recommending daily Codeforces problems; 2500+ users with a 4.9★ rating."
             imageSrc="/images/project1.svg"
             link="#"
           />
           <ProjectCard
-            title="Project Two"
-            description="Description of project two."
+            title="Image Encryption App"
+            description="Java Swing tool using chaotic logistic maps for fast image encryption."
             imageSrc="/images/project2.svg"
             link="#"
           />
@@ -99,11 +104,26 @@ export default function Home() {
       >
         <h1 className="text-4xl font-bold mb-4">Experience</h1>
         <ul className="border-l-2 border-gray-300 ml-2">
-          <TimelineItem title="Company A" subtitle="Role" date="2020 - Present">
-            Brief description of your role at Company A.
+          <TimelineItem
+            title="Nielsen Media"
+            subtitle="Member of Technical Staff"
+            date="Jul 2024 - Present"
+          >
+            Developed event-driven microservices and automated data pipelines using AWS, Redis, and Airflow.
           </TimelineItem>
-          <TimelineItem title="Company B" subtitle="Role" date="2018 - 2020">
-            Brief description of your role at Company B.
+          <TimelineItem
+            title="SAP Labs"
+            subtitle="Developer Intern"
+            date="Feb 2024 - Jul 2024"
+          >
+            Created an SAPUI5 logging plugin and internal DevOps tools with Jira integrations.
+          </TimelineItem>
+          <TimelineItem
+            title="IIIT Delhi"
+            subtitle="R&amp;D Intern"
+            date="Jun 2023 - Dec 2023"
+          >
+            Built a mobile app for patented research using smartphone sensors.
           </TimelineItem>
         </ul>
       </motion.section>
@@ -117,7 +137,18 @@ export default function Home() {
         viewport={{ once: true }}
       >
         <h1 className="text-4xl font-bold mb-4">Skills</h1>
-        <p>List your skills here.</p>
+        <h2 className="text-2xl font-semibold mt-4">Languages</h2>
+        <ul className="list-disc list-inside text-left">
+          <li>C++, Java, JavaScript, Python, SQL, Bash</li>
+        </ul>
+        <h2 className="text-2xl font-semibold mt-4">Technologies</h2>
+        <ul className="list-disc list-inside text-left">
+          <li>
+            AWS, Apache Airflow, Kubernetes, Docker, Redis, Presto/PostgreSQL,
+            Maven, Gradle, CI/CD, Google Cloud, Grafana, Node.js, HTML/CSS,
+            Terraform, Terragrunt, Spark, Git, Linux
+          </li>
+        </ul>
       </motion.section>
 
       <motion.section
@@ -129,7 +160,16 @@ export default function Home() {
         viewport={{ once: true }}
       >
         <h1 className="text-4xl font-bold mb-4">Achievements</h1>
-        <p>Share your achievements here.</p>
+        <ul className="list-disc list-inside text-left">
+          <li>
+            Global rank&nbsp;103 among 10k+ participants in a CodeChef Div&nbsp;2
+            contest.
+          </li>
+          <li>
+            Keyboard player certified by Trinity College London with one of its
+            highest rankings.
+          </li>
+        </ul>
       </motion.section>
 
       <motion.section

--- a/pages/projects.tsx
+++ b/pages/projects.tsx
@@ -11,14 +11,14 @@ export default function Projects() {
       <h1 className="text-4xl font-bold mb-4">Projects</h1>
       <div className="grid gap-4 md:grid-cols-2">
         <ProjectCard
-          title="Project One"
-          description="Description of project one."
+          title="Codeforces POTD Extension"
+          description="Chrome extension recommending daily Codeforces problems; 2500+ users with a 4.9★ rating."
           imageSrc="/images/project1.svg"
           link="#"
         />
         <ProjectCard
-          title="Project Two"
-          description="Description of project two."
+          title="Image Encryption App"
+          description="Java Swing tool using chaotic logistic maps for fast image encryption."
           imageSrc="/images/project2.svg"
           link="#"
         />

--- a/pages/skills.tsx
+++ b/pages/skills.tsx
@@ -8,7 +8,18 @@ export default function Skills() {
         <meta name="description" content="Technical skills and proficiencies." />
       </Head>
       <h1 className="text-4xl font-bold mb-4">Skills</h1>
-      <p>List your skills here.</p>
+      <h2 className="text-2xl font-semibold mt-4">Languages</h2>
+      <ul className="list-disc list-inside text-left">
+        <li>C++, Java, JavaScript, Python, SQL, Bash</li>
+      </ul>
+      <h2 className="text-2xl font-semibold mt-4">Technologies</h2>
+      <ul className="list-disc list-inside text-left">
+        <li>
+          AWS, Apache Airflow, Kubernetes, Docker, Redis, Presto/PostgreSQL,
+          Maven, Gradle, CI/CD, Google Cloud, Grafana, Node.js, HTML/CSS,
+          Terraform, Terragrunt, Spark, Git, Linux
+        </li>
+      </ul>
     </>
   )
 }


### PR DESCRIPTION
## Summary
- fill in placeholder text with real resume details
- add timeline entries for work experience
- list skills and achievements
- show project information
- customize hero banner and navigation

## Testing
- `npm install`
- `npm run lint` *(fails: prompts for interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68593f58d43883318076f42b5f1f6dee