### PR TITLE
Enable class-based dark mode

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react'
+import { ReactNode, useEffect, useState } from 'react'
 import Navbar from './Navbar'
 import Footer from './Footer'
 
@@ -7,9 +7,32 @@ interface Props {
 }
 
 export default function Layout({ children }: Props) {
+  const [theme, setTheme] = useState<'light' | 'dark'>('light')
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme') as 'light' | 'dark' | null
+    if (stored) {
+      setTheme(stored)
+      if (stored === 'dark') {
+        document.documentElement.classList.add('dark')
+      }
+    }
+  }, [])
+
+  function toggleTheme() {
+    const next = theme === 'light' ? 'dark' : 'light'
+    setTheme(next)
+    if (next === 'dark') {
+      document.documentElement.classList.add('dark')
+    } else {
+      document.documentElement.classList.remove('dark')
+    }
+    localStorage.setItem('theme', next)
+  }
+
   return (
     <div className="flex min-h-screen flex-col">
-      <Navbar />
+      <Navbar theme={theme} onToggleTheme={toggleTheme} />
       <main id="main-content" className="flex-grow container mx-auto px-4 py-8">
         {children}
       </main>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,42 +1,56 @@
 import Link from 'next/link'
 
-export default function Navbar() {
+interface Props {
+  theme: 'light' | 'dark'
+  onToggleTheme: () => void
+}
+
+export default function Navbar({ theme, onToggleTheme }: Props) {
   return (
     <header className="bg-gradient-to-r from-indigo-600 via-purple-600 to-pink-600 text-white shadow-md sticky top-0 z-50">
       <nav className="container mx-auto flex items-center justify-between p-4" aria-label="Main navigation">
         <Link href="/" className="text-xl font-semibold">Anant Kumar Srivastava</Link>
-        <ul className="flex space-x-4">
-          <li>
-            <Link href="#about" className="hover:text-yellow-300">
-              About
-            </Link>
-          </li>
-          <li>
-            <Link href="#projects" className="hover:text-yellow-300">
-              Projects
-            </Link>
-          </li>
-          <li>
-            <Link href="#experience" className="hover:text-yellow-300">
-              Experience
-            </Link>
-          </li>
-          <li>
-            <Link href="#skills" className="hover:text-yellow-300">
-              Skills
-            </Link>
-          </li>
-          <li>
-            <Link href="#achievements" className="hover:text-yellow-300">
-              Achievements
-            </Link>
-          </li>
-          <li>
-            <Link href="#contact" className="hover:text-yellow-300">
-              Contact
-            </Link>
-          </li>
-        </ul>
+        <div className="flex items-center space-x-4">
+          <ul className="flex space-x-4">
+            <li>
+              <Link href="#about" className="hover:text-yellow-300">
+                About
+              </Link>
+            </li>
+            <li>
+              <Link href="#projects" className="hover:text-yellow-300">
+                Projects
+              </Link>
+            </li>
+            <li>
+              <Link href="#experience" className="hover:text-yellow-300">
+                Experience
+              </Link>
+            </li>
+            <li>
+              <Link href="#skills" className="hover:text-yellow-300">
+                Skills
+              </Link>
+            </li>
+            <li>
+              <Link href="#achievements" className="hover:text-yellow-300">
+                Achievements
+              </Link>
+            </li>
+            <li>
+              <Link href="#contact" className="hover:text-yellow-300">
+                Contact
+              </Link>
+            </li>
+          </ul>
+          <button
+            onClick={onToggleTheme}
+            aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+            className="p-2 rounded hover:bg-white/20"
+          >
+            {theme === 'dark' ? '🌞' : '🌙'}
+          </button>
+        </div>
       </nav>
     </header>
   )

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -5,6 +5,6 @@
 @tailwind utilities;
 
 body {
-  @apply font-sans text-gray-800;
+  @apply font-sans bg-white text-gray-800 dark:bg-gray-900 dark:text-gray-100;
   scroll-behavior: smooth;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: [
     "./pages/**/*.{js,ts,jsx,tsx}",
     "./components/**/*.{js,ts,jsx,tsx}"


### PR DESCRIPTION
## Summary
- enable class-based dark mode configuration in Tailwind
- apply default light/dark colors in globals CSS
- manage theme state in `Layout` and persist to localStorage
- update `Navbar` with accessible theme toggle

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6859454658fc833184239d3017e289df