### PR TITLE
Add accent color and heading fonts

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,6 +1,6 @@
 export default function Footer() {
   return (
-    <footer className="bg-gray-900 text-gray-300 mt-auto" role="contentinfo">
+    <footer className="bg-dark text-gray-300 mt-auto" role="contentinfo">
       <div className="container mx-auto px-4 py-6 text-center text-sm">
         &copy; {new Date().getFullYear()} Anant Kumar Srivastava
       </div>

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -7,11 +7,11 @@ export default function Hero() {
       className="py-32 text-center bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 text-white"
       aria-label="Introduction"
     >
-      <h1 className="text-6xl font-extrabold mb-6">Hi, I'm Anant Kumar Srivastava.</h1>
+      <h1 className="text-6xl font-extrabold font-heading mb-6 text-accent">Hi, I'm Anant Kumar Srivastava.</h1>
       <p className="text-2xl mb-8">Software engineer building data-driven services and user-friendly tools.</p>
       <Link
         href="#projects"
-        className="inline-block bg-white text-indigo-700 px-6 py-3 rounded shadow hover:bg-gray-100"
+        className="inline-block bg-white text-accent px-6 py-3 rounded shadow hover:bg-gray-100"
       >
         View Projects
       </Link>

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -31,7 +31,7 @@ export default function Layout({ children }: Props) {
   }
 
   return (
-    <div className="flex min-h-screen flex-col">
+    <div className="flex min-h-screen flex-col bg-white dark:bg-dark">
       <Navbar theme={theme} onToggleTheme={toggleTheme} />
       <main id="main-content" className="flex-grow container mx-auto px-4 py-8">
         {children}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -9,36 +9,36 @@ export default function Navbar({ theme, onToggleTheme }: Props) {
   return (
     <header className="bg-gradient-to-r from-indigo-600 via-purple-600 to-pink-600 text-white shadow-md sticky top-0 z-50">
       <nav className="container mx-auto flex items-center justify-between p-4" aria-label="Main navigation">
-        <Link href="/" className="text-xl font-semibold">Anant Kumar Srivastava</Link>
+        <Link href="/" className="text-xl font-semibold font-heading text-accent">Anant Kumar Srivastava</Link>
         <div className="flex items-center space-x-4">
           <ul className="flex space-x-4">
             <li>
-              <Link href="#about" className="hover:text-yellow-300">
+              <Link href="#about" className="hover:text-accent">
                 About
               </Link>
             </li>
             <li>
-              <Link href="#projects" className="hover:text-yellow-300">
+              <Link href="#projects" className="hover:text-accent">
                 Projects
               </Link>
             </li>
             <li>
-              <Link href="#experience" className="hover:text-yellow-300">
+              <Link href="#experience" className="hover:text-accent">
                 Experience
               </Link>
             </li>
             <li>
-              <Link href="#skills" className="hover:text-yellow-300">
+              <Link href="#skills" className="hover:text-accent">
                 Skills
               </Link>
             </li>
             <li>
-              <Link href="#achievements" className="hover:text-yellow-300">
+              <Link href="#achievements" className="hover:text-accent">
                 Achievements
               </Link>
             </li>
             <li>
-              <Link href="#contact" className="hover:text-yellow-300">
+              <Link href="#contact" className="hover:text-accent">
                 Contact
               </Link>
             </li>

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -17,12 +17,12 @@ export default function ProjectCard({ title, description, imageSrc, link }: Prop
         height={400}
         className="mb-2 rounded"
       />
-      <h3 id={title.replace(/\s+/g, '-') + '-title'} className="text-xl font-semibold mb-2">
+      <h3 id={title.replace(/\s+/g, '-') + '-title'} className="text-xl font-semibold font-heading mb-2">
         {title}
       </h3>
       <p className="mb-2 text-gray-700">{description}</p>
       {link && (
-        <a href={link} className="text-indigo-600 hover:underline" target="_blank" rel="noopener noreferrer">
+        <a href={link} className="text-accent hover:underline" target="_blank" rel="noopener noreferrer">
           View More
         </a>
       )}

--- a/components/TimelineItem.tsx
+++ b/components/TimelineItem.tsx
@@ -8,9 +8,9 @@ interface Props {
 export default function TimelineItem({ title, subtitle, date, children }: Props) {
   return (
     <li className="relative pl-8 pb-8">
-      <div className="absolute left-0 top-1.5 h-3 w-3 rounded-full bg-indigo-600" aria-hidden="true" />
+      <div className="absolute left-0 top-1.5 h-3 w-3 rounded-full bg-accent" aria-hidden="true" />
       <div>
-        <h3 className="text-lg font-semibold">{title}</h3>
+        <h3 className="text-lg font-semibold font-heading">{title}</h3>
         {subtitle && <p className="text-sm text-gray-600">{subtitle}</p>}
         <time className="block text-sm text-gray-500" dateTime={date}>{date}</time>
         {children && <p className="mt-2 text-gray-700">{children}</p>}

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -18,7 +18,7 @@ export default function About() {
         height={200}
         className="mx-auto rounded-full mb-4"
       />
-      <h1 className="text-4xl font-bold mb-4">About Me</h1>
+      <h1 className="text-4xl font-bold font-heading mb-4">About Me</h1>
       <p>
         I'm Anant Kumar Srivastava, a software engineer with a B.E. in Electronics
         and Instrumentation and an M.Sc. in Mathematics from BITS Pilani

--- a/pages/achievements.tsx
+++ b/pages/achievements.tsx
@@ -10,7 +10,7 @@ export default function Achievements() {
         <meta property="og:description" content="Awards and notable achievements." />
         <meta property="og:image" content="/images/profile.svg" />
       </Head>
-      <h1 className="text-4xl font-bold mb-4">Achievements</h1>
+      <h1 className="text-4xl font-bold font-heading mb-4">Achievements</h1>
       <ul className="list-disc list-inside text-left">
         <li>
           Global rank&nbsp;103 among 10k+ participants in a CodeChef Div&nbsp;2

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -40,7 +40,7 @@ export default function Contact() {
         <meta property="og:description" content="Get in touch using the contact form." />
         <meta property="og:image" content="/images/profile.svg" />
       </Head>
-      <h1 className="text-4xl font-bold mb-4">Contact</h1>
+      <h1 className="text-4xl font-bold font-heading mb-4">Contact</h1>
       <form onSubmit={handleSubmit} className="max-w-md space-y-4" aria-label="Contact form">
         <label className="block" htmlFor="contact-name">
           <span className="sr-only">Name</span>
@@ -54,7 +54,7 @@ export default function Contact() {
           <span className="sr-only">Message</span>
           <textarea id="contact-message" className="w-full p-2 border" name="message" placeholder="Message" required />
         </label>
-        <button type="submit" className="px-4 py-2 bg-blue-500 text-white">Send</button>
+        <button type="submit" className="px-4 py-2 bg-accent text-white">Send</button>
       </form>
       {status && <p className="mt-4" role="status">{status}</p>}
     </>

--- a/pages/experience.tsx
+++ b/pages/experience.tsx
@@ -11,7 +11,7 @@ export default function Experience() {
         <meta property="og:description" content="Professional work and experiences." />
         <meta property="og:image" content="/images/profile.svg" />
       </Head>
-      <h1 className="text-4xl font-bold mb-4">Experience</h1>
+      <h1 className="text-4xl font-bold font-heading mb-4">Experience</h1>
       <ul className="border-l-2 border-gray-300 ml-2">
         <TimelineItem
           title="Nielsen Media"

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -63,7 +63,7 @@ export default function Home() {
           height={200}
           className="mx-auto rounded-full mb-4"
         />
-        <h1 className="text-4xl font-bold mb-4">About Me</h1>
+        <h1 className="text-4xl font-bold font-heading mb-4">About Me</h1>
         <p>
           I'm Anant Kumar Srivastava, a software engineer with a B.E. in
           Electronics and Instrumentation and an M.Sc. in Mathematics from BITS
@@ -80,7 +80,7 @@ export default function Home() {
         transition={{ duration: 0.6 }}
         viewport={{ once: true }}
       >
-        <h1 className="text-4xl font-bold mb-4">Projects</h1>
+        <h1 className="text-4xl font-bold font-heading mb-4">Projects</h1>
         <div className="grid gap-4 md:grid-cols-2">
           <ProjectCard
             title="Codeforces POTD Extension"
@@ -105,7 +105,7 @@ export default function Home() {
         transition={{ duration: 0.6 }}
         viewport={{ once: true }}
       >
-        <h1 className="text-4xl font-bold mb-4">Experience</h1>
+        <h1 className="text-4xl font-bold font-heading mb-4">Experience</h1>
         <ul className="border-l-2 border-gray-300 ml-2">
           <TimelineItem
             title="Nielsen Media"
@@ -139,12 +139,12 @@ export default function Home() {
         transition={{ duration: 0.6 }}
         viewport={{ once: true }}
       >
-        <h1 className="text-4xl font-bold mb-4">Skills</h1>
-        <h2 className="text-2xl font-semibold mt-4">Languages</h2>
+        <h1 className="text-4xl font-bold font-heading mb-4">Skills</h1>
+        <h2 className="text-2xl font-semibold font-heading mt-4">Languages</h2>
         <ul className="list-disc list-inside text-left">
           <li>C++, Java, JavaScript, Python, SQL, Bash</li>
         </ul>
-        <h2 className="text-2xl font-semibold mt-4">Technologies</h2>
+        <h2 className="text-2xl font-semibold font-heading mt-4">Technologies</h2>
         <ul className="list-disc list-inside text-left">
           <li>
             AWS, Apache Airflow, Kubernetes, Docker, Redis, Presto/PostgreSQL,
@@ -162,7 +162,7 @@ export default function Home() {
         transition={{ duration: 0.6 }}
         viewport={{ once: true }}
       >
-        <h1 className="text-4xl font-bold mb-4">Achievements</h1>
+        <h1 className="text-4xl font-bold font-heading mb-4">Achievements</h1>
         <ul className="list-disc list-inside text-left">
           <li>
             Global rank&nbsp;103 among 10k+ participants in a CodeChef Div&nbsp;2
@@ -183,7 +183,7 @@ export default function Home() {
         transition={{ duration: 0.6 }}
         viewport={{ once: true }}
       >
-        <h1 className="text-4xl font-bold mb-4">Contact</h1>
+        <h1 className="text-4xl font-bold font-heading mb-4">Contact</h1>
         <form onSubmit={handleSubmit} className="max-w-md space-y-4 mx-auto" aria-label="Contact form">
           <label className="block" htmlFor="home-contact-name">
             <span className="sr-only">Name</span>
@@ -197,7 +197,7 @@ export default function Home() {
             <span className="sr-only">Message</span>
             <textarea id="home-contact-message" className="w-full p-2 border" name="message" placeholder="Message" required />
           </label>
-          <button type="submit" className="px-4 py-2 bg-blue-500 text-white">Send</button>
+          <button type="submit" className="px-4 py-2 bg-accent text-white">Send</button>
         </form>
         {status && <p className="mt-4" role="status">{status}</p>}
       </motion.section>

--- a/pages/projects.tsx
+++ b/pages/projects.tsx
@@ -11,7 +11,7 @@ export default function Projects() {
         <meta property="og:description" content="A showcase of my projects and work." />
         <meta property="og:image" content="/images/profile.svg" />
       </Head>
-      <h1 className="text-4xl font-bold mb-4">Projects</h1>
+      <h1 className="text-4xl font-bold font-heading mb-4">Projects</h1>
       <div className="grid gap-4 md:grid-cols-2">
         <ProjectCard
           title="Codeforces POTD Extension"

--- a/pages/skills.tsx
+++ b/pages/skills.tsx
@@ -10,12 +10,12 @@ export default function Skills() {
         <meta property="og:description" content="Technical skills and proficiencies." />
         <meta property="og:image" content="/images/profile.svg" />
       </Head>
-      <h1 className="text-4xl font-bold mb-4">Skills</h1>
-      <h2 className="text-2xl font-semibold mt-4">Languages</h2>
+      <h1 className="text-4xl font-bold font-heading mb-4">Skills</h1>
+      <h2 className="text-2xl font-semibold font-heading mt-4">Languages</h2>
       <ul className="list-disc list-inside text-left">
         <li>C++, Java, JavaScript, Python, SQL, Bash</li>
       </ul>
-      <h2 className="text-2xl font-semibold mt-4">Technologies</h2>
+      <h2 className="text-2xl font-semibold font-heading mt-4">Technologies</h2>
       <ul className="list-disc list-inside text-left">
         <li>
           AWS, Apache Airflow, Kubernetes, Docker, Redis, Presto/PostgreSQL,

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,10 +1,11 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;700&display=swap');
 
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 body {
-  @apply font-sans bg-white text-gray-800 dark:bg-gray-900 dark:text-gray-100;
+  @apply font-sans bg-white text-gray-800 dark:bg-dark dark:text-gray-100;
   scroll-behavior: smooth;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,8 +7,13 @@ module.exports = {
   ],
   theme: {
     extend: {
+      colors: {
+        accent: '#00ffff',
+        dark: '#121212',
+      },
       fontFamily: {
         sans: ['Inter', 'ui-sans-serif', 'system-ui'],
+        heading: ['Poppins', 'sans-serif'],
       },
     },
   },


### PR DESCRIPTION
## Summary
- extend Tailwind theme with accent and dark colors
- add Poppins heading font stack
- import the font and tweak global styles
- apply `font-heading`, `text-accent`, and `bg-dark` across components

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm run build` *(fails: type errors in pages/index.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_688b9d47e3b48331b3f13ddceb69ed85