### PR TITLE
Add animated hover border for project cards

### DIFF
--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image'
+import { motion, useReducedMotion } from 'framer-motion'
 
 interface Props {
   title: string
@@ -8,8 +9,16 @@ interface Props {
 }
 
 export default function ProjectCard({ title, description, imageSrc, link }: Props) {
+  const shouldReduceMotion = useReducedMotion()
+
   return (
-    <article className="border rounded-lg p-4 shadow-lg bg-white" aria-labelledby={title.replace(/\s+/g, '-') + '-title'}>
+    <motion.article
+      className="relative rounded-lg p-4 shadow-lg bg-white group"
+      aria-labelledby={title.replace(/\s+/g, '-') + '-title'}
+      initial={false}
+      whileHover={shouldReduceMotion ? {} : { scale: 1.02 }}
+      transition={{ duration: shouldReduceMotion ? 0 : 0.4 }}
+    >
       <Image
         src={imageSrc}
         alt={title + ' screenshot'}
@@ -20,12 +29,39 @@ export default function ProjectCard({ title, description, imageSrc, link }: Prop
       <h3 id={title.replace(/\s+/g, '-') + '-title'} className="text-xl font-semibold font-heading mb-2">
         {title}
       </h3>
-      <p className="mb-2 text-gray-700">{description}</p>
-      {link && (
-        <a href={link} className="text-accent hover:underline" target="_blank" rel="noopener noreferrer">
-          View More
-        </a>
-      )}
-    </article>
+      <motion.div
+        initial={{ opacity: shouldReduceMotion ? 1 : 0 }}
+        whileHover={{ opacity: 1 }}
+        transition={{ duration: shouldReduceMotion ? 0 : 0.4 }}
+      >
+        <p className="mb-2 text-gray-700">{description}</p>
+        {link && (
+          <a href={link} className="text-accent hover:underline" target="_blank" rel="noopener noreferrer">
+            View More
+          </a>
+        )}
+      </motion.div>
+      <motion.svg
+        viewBox="0 0 100 100"
+        preserveAspectRatio="none"
+        className="absolute inset-0 w-full h-full pointer-events-none text-accent"
+        initial={{ opacity: 0, pathLength: 0 }}
+        whileHover={{ opacity: 1, pathLength: 1 }}
+        transition={{ duration: shouldReduceMotion ? 0 : 0.4 }}
+        aria-hidden="true"
+      >
+        <motion.rect
+          x="1"
+          y="1"
+          width="98"
+          height="98"
+          rx="8"
+          ry="8"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+        />
+      </motion.svg>
+    </motion.article>
   )
 }


### PR DESCRIPTION
## Summary
- give project cards a hand-drawn border using an absolutely positioned SVG
- fade in project details on hover with framer motion

## Testing
- `npm run lint` *(fails: asks about ESLint config)*
- `npm run build` *(fails: TypeScript error in pages/index.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_688c82d5dfb88331ab771513ca2e1936