### PR TITLE
Refactor contact forms into reusable component

### DIFF
--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react'
+
+export async function handleSubmit(
+  e: React.FormEvent<HTMLFormElement>,
+  setStatus: (status: string | null) => void
+) {
+  e.preventDefault()
+  const form = e.currentTarget
+  const data = {
+    name: (form.elements.namedItem('name') as HTMLInputElement)?.value || '',
+    email: (form.elements.namedItem('email') as HTMLInputElement)?.value || '',
+    message: (form.elements.namedItem('message') as HTMLTextAreaElement)?.value || '',
+  }
+
+  try {
+    const res = await fetch('/api/contact', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    if (res.ok) {
+      setStatus('Message sent!')
+      form.reset()
+    } else {
+      const body = await res.json()
+      setStatus(body.error || 'Something went wrong')
+    }
+  } catch (err) {
+    setStatus('Failed to submit form')
+  }
+}
+
+interface Props {
+  idPrefix?: string
+  className?: string
+}
+
+export default function ContactForm({ idPrefix = 'contact', className = 'max-w-md space-y-4' }: Props) {
+  const [status, setStatus] = useState<string | null>(null)
+
+  return (
+    <>
+      <form onSubmit={(e) => handleSubmit(e, setStatus)} className={className} aria-label="Contact form">
+        <label className="block" htmlFor={`${idPrefix}-name`}>
+          <span className="sr-only">Name</span>
+          <input id={`${idPrefix}-name`} className="w-full p-2 border" name="name" placeholder="Name" required />
+        </label>
+        <label className="block" htmlFor={`${idPrefix}-email`}>
+          <span className="sr-only">Email</span>
+          <input id={`${idPrefix}-email`} className="w-full p-2 border" name="email" type="email" placeholder="Email" required />
+        </label>
+        <label className="block" htmlFor={`${idPrefix}-message`}>
+          <span className="sr-only">Message</span>
+          <textarea id={`${idPrefix}-message`} className="w-full p-2 border" name="message" placeholder="Message" required />
+        </label>
+        <button type="submit" className="px-4 py-2 bg-accent text-white">Send</button>
+      </form>
+      {status && (
+        <p className="mt-4" role="status">
+          {status}
+        </p>
+      )}
+    </>
+  )
+}

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -1,35 +1,7 @@
-import { useState } from 'react'
 import Head from 'next/head'
+import ContactForm from '../components/ContactForm'
 
 export default function Contact() {
-  const [status, setStatus] = useState<string | null>(null)
-
-  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
-    e.preventDefault()
-    const form = e.currentTarget as HTMLFormElement
-    const data = {
-      name: (form.elements.namedItem('name') as HTMLInputElement)?.value || '',
-      email: (form.elements.namedItem('email') as HTMLInputElement)?.value || '',
-      message: (form.elements.namedItem('message') as HTMLTextAreaElement)?.value || '',
-    }
-
-    try {
-      const res = await fetch('/api/contact', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data),
-      })
-      if (res.ok) {
-        setStatus('Message sent!')
-        form.reset()
-      } else {
-        const body = await res.json()
-        setStatus(body.error || 'Something went wrong')
-      }
-    } catch (err) {
-      setStatus('Failed to submit form')
-    }
-  }
 
   return (
     <>
@@ -41,22 +13,7 @@ export default function Contact() {
         <meta property="og:image" content="/images/profile.svg" />
       </Head>
       <h1 className="text-4xl font-bold font-heading mb-4">Contact</h1>
-      <form onSubmit={handleSubmit} className="max-w-md space-y-4" aria-label="Contact form">
-        <label className="block" htmlFor="contact-name">
-          <span className="sr-only">Name</span>
-          <input id="contact-name" className="w-full p-2 border" name="name" placeholder="Name" required />
-        </label>
-        <label className="block" htmlFor="contact-email">
-          <span className="sr-only">Email</span>
-          <input id="contact-email" className="w-full p-2 border" name="email" type="email" placeholder="Email" required />
-        </label>
-        <label className="block" htmlFor="contact-message">
-          <span className="sr-only">Message</span>
-          <textarea id="contact-message" className="w-full p-2 border" name="message" placeholder="Message" required />
-        </label>
-        <button type="submit" className="px-4 py-2 bg-accent text-white">Send</button>
-      </form>
-      {status && <p className="mt-4" role="status">{status}</p>}
+      <ContactForm idPrefix="contact" />
     </>
   )
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,40 +1,13 @@
 import Head from 'next/head'
 import Image from 'next/image'
-import { useState } from 'react'
+
+import ContactForm from '../components/ContactForm'
 import { motion } from 'framer-motion'
 import Hero from '../components/Hero'
 import ProjectCard from '../components/ProjectCard'
 import TimelineItem from '../components/TimelineItem'
 
 export default function Home() {
-  const [status, setStatus] = useState<string | null>(null)
-
-  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
-    e.preventDefault()
-    const form = e.currentTarget
-    const data = {
-      name: form.name.value,
-      email: form.email.value,
-      message: form.message.value,
-    }
-
-    try {
-      const res = await fetch('/api/contact', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data),
-      })
-      if (res.ok) {
-        setStatus('Message sent!')
-        form.reset()
-      } else {
-        const body = await res.json()
-        setStatus(body.error || 'Something went wrong')
-      }
-    } catch (err) {
-      setStatus('Failed to submit form')
-    }
-  }
 
   return (
     <>
@@ -184,22 +157,7 @@ export default function Home() {
         viewport={{ once: true }}
       >
         <h1 className="text-4xl font-bold font-heading mb-4">Contact</h1>
-        <form onSubmit={handleSubmit} className="max-w-md space-y-4 mx-auto" aria-label="Contact form">
-          <label className="block" htmlFor="home-contact-name">
-            <span className="sr-only">Name</span>
-            <input id="home-contact-name" className="w-full p-2 border" name="name" placeholder="Name" required />
-          </label>
-          <label className="block" htmlFor="home-contact-email">
-            <span className="sr-only">Email</span>
-            <input id="home-contact-email" className="w-full p-2 border" name="email" type="email" placeholder="Email" required />
-          </label>
-          <label className="block" htmlFor="home-contact-message">
-            <span className="sr-only">Message</span>
-            <textarea id="home-contact-message" className="w-full p-2 border" name="message" placeholder="Message" required />
-          </label>
-          <button type="submit" className="px-4 py-2 bg-accent text-white">Send</button>
-        </form>
-        {status && <p className="mt-4" role="status">{status}</p>}
+        <ContactForm idPrefix="home-contact" className="max-w-md space-y-4 mx-auto" />
       </motion.section>
     </>
   )


### PR DESCRIPTION
## Summary
- add a `ContactForm` component with shared submit logic
- replace duplicated forms on the index and contact pages
- export `handleSubmit` for reuse

## Testing
- `CI=true npx next lint` *(fails: prompts for interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_688c8c392de8833190b63ca7bdf4e3de