### PR TITLE
Add instrument showcase component and custom fonts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "react-dom": "18.2.0",
         "react-github-calendar": "^4.5.9",
         "react-helmet": "^6.1.0",
+        "react-icons": "^5.5.0",
         "react-router-dom": "^6.22.0",
         "tailwind-merge": "^3.3.1"
       },
@@ -3610,6 +3611,15 @@
       },
       "peerDependencies": {
         "react": ">=16.3.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -18,18 +18,19 @@
     "react-dom": "18.2.0",
     "react-github-calendar": "^4.5.9",
     "react-helmet": "^6.1.0",
+    "react-icons": "^5.5.0",
     "react-router-dom": "^6.22.0",
     "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {
     "@types/node": "20.10.5",
     "@types/react": "18.2.21",
+    "@vitejs/plugin-react": "^4.1.0",
     "autoprefixer": "^10.4.17",
     "eslint": "8.56.0",
     "postcss": "^8.4.33",
     "tailwindcss": "^3.4.3",
     "typescript": "5.3.3",
-    "vite": "^5.2.0",
-    "@vitejs/plugin-react": "^4.1.0"
+    "vite": "^5.2.0"
   }
 }

--- a/src/components/InstrumentShowcase.tsx
+++ b/src/components/InstrumentShowcase.tsx
@@ -1,0 +1,28 @@
+import { motion } from 'framer-motion'
+import { FaGuitar } from 'react-icons/fa'
+import { GiPianoKeys } from 'react-icons/gi'
+
+export default function InstrumentShowcase() {
+  const instruments = [
+    { label: 'Piano', icon: <GiPianoKeys /> },
+    { label: 'Guitar', icon: <FaGuitar /> },
+  ]
+
+  return (
+    <section className="py-20">
+      <h2 className="text-4xl font-heading text-center mb-8">Instruments</h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-8 max-w-2xl mx-auto">
+        {instruments.map(({ label, icon }) => (
+          <motion.div
+            key={label}
+            whileHover={{ y: -4, boxShadow: '0 5px 15px rgba(0,0,0,0.4)' }}
+            className="backdrop-blur-md bg-glass-dark p-6 rounded-xl text-center"
+          >
+            <div className="text-5xl text-accent mb-2">{icon}</div>
+            <p className="text-lg text-gray-200">{label}</p>
+          </motion.div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Crimson+Text:wght@700&display=swap');
 
 @tailwind base;
 @tailwind components;
@@ -13,7 +12,7 @@
 /* Basic body styles */
 body {
   font-family: 'Inter', ui-sans-serif, system-ui, sans-serif;
-  background: #0c4a6e;
+  background: #0D0D0D;
   color: #f3f4f6;
   scroll-behavior: smooth;
   margin: 0;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -20,6 +20,10 @@ module.exports = {
           900: '#0c4a6e',
         },
         accent: '#00ffff',
+        accentBlue: '#00ffff',
+        accentRed: '#ff006e',
+        accentViolet: '#8b5cf6',
+        matte: '#0D0D0D',
         dark: {
           50: '#fafafa',
           100: '#f4f4f5',
@@ -41,7 +45,7 @@ module.exports = {
       },
       fontFamily: {
         sans: ['Inter', 'ui-sans-serif', 'system-ui'],
-        heading: ['Poppins', 'sans-serif'],
+        heading: ['"Crimson Text"', 'serif'],
         mono: ['JetBrains Mono', 'ui-monospace', 'monospace'],
       },
       backdropBlur: {


### PR DESCRIPTION
## Summary
- add `Crimson Text` font and matte black base in CSS
- expose accent variations and matte color in Tailwind
- switch heading font to use Crimson Text
- create `InstrumentShowcase` component with framer motion
- install `react-icons`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688d2474c8b48331997aa02a8211add6